### PR TITLE
Use encodeURIComponent() for feeds in subscription URLs 

### DIFF
--- a/ts/feedReaders.ts
+++ b/ts/feedReaders.ts
@@ -9,64 +9,64 @@ export const FeedReaders: FeedReader[] = [
 	{
 		id: "feedly",
 		name: "Feedly",
-		link: feed => `https://feedly.com/i/subscription/feed/${encodeURI(feed)}`,
+		link: feed => `https://feedly.com/i/subscription/feed/${encodeURIComponent(feed)}`,
 		favicon: "feedly.svg",
 	},
 	{
 		id: "theoldreader",
 		name: "The Old Reader",
 		link: feed =>
-			`https://theoldreader.com/feeds/subscribe?url=${encodeURI(feed)}`,
+			`https://theoldreader.com/feeds/subscribe?url=${encodeURIComponent(feed)}`,
 		favicon: "theoldreader.png",
 	},
 	{
 		id: "inoreader",
 		name: "Inoreader",
-		link: feed => `http://www.inoreader.com/feed/${encodeURI(feed)}`,
+		link: feed => `http://www.inoreader.com/feed/${encodeURIComponent(feed)}`,
 		favicon: "inoreader.ico",
 	},
 	{
 		id: "newsblur",
 		name: "News Blur",
-		link: feed => `http://www.newsblur.com/?url=${encodeURI(feed)}`,
+		link: feed => `http://www.newsblur.com/?url=${encodeURIComponent(feed)}`,
 		favicon: "newsblur.png",
 	},
 	{
 		id: "netvibes",
 		name: "Netvibes",
 		link: feed =>
-			`https://www.netvibes.com/subscribe.php?url=${encodeURI(feed)}`,
+			`https://www.netvibes.com/subscribe.php?url=${encodeURIComponent(feed)}`,
 		favicon: "netvibes.png",
 	},
 	{
 		id: "bazqux",
 		name: "BazQux",
-		link: feed => `https://bazqux.com/add?url=${encodeURI(feed)}`,
+		link: feed => `https://bazqux.com/add?url=${encodeURIComponent(feed)}`,
 		favicon: "bazqux.ico",
 	},
 	{
 		id: "feedbin",
 		name: "Feedbin",
-		link: feed => `https://feedbin.me/?subscribe=${encodeURI(feed)}`,
+		link: feed => `https://feedbin.me/?subscribe=${encodeURIComponent(feed)}`,
 		favicon: "feedbin.ico",
 	},
 	{
 		id: "g2reader",
 		name: "G2Reader",
-		link: feed => `https://g2reader.com/?add&q=${encodeURI(feed)}`,
+		link: feed => `https://g2reader.com/?add&q=${encodeURIComponent(feed)}`,
 		favicon: "g2reader.ico",
 	},
 	{
 		id: "commafeed",
 		name: "CommaFeed",
 		link: feed =>
-			`https://www.commafeed.com/rest/feed/subscribe?url=${encodeURI(feed)}`,
+			`https://www.commafeed.com/rest/feed/subscribe?url=${encodeURIComponent(feed)}`,
 		favicon: "commafeed.ico",
 	},
 	{
 		id: "nooshub",
 		name: "Nooshub",
-		link: feed => `https://www.nooshub.com/me/feeds/new?url=${encodeURI(feed)}`,
+		link: feed => `https://www.nooshub.com/me/feeds/new?url=${encodeURIComponent(feed)}`,
 		favicon: "nooshub.ico",
 	},
 ];


### PR DESCRIPTION
Use encodeURIComponent() for feeds in subscription URLs make feeds with parameters in the feed-URL work.
encodeURI() doesn't encode "&" in feed-URLs, so parameters looked like parameters to the subscription URL instead of part of the feed-URLs.
This should fix issue #26 .