### PR TITLE
Use encodeURIComponent() for feed URLs in custom readers

### DIFF
--- a/ts/storage.ts
+++ b/ts/storage.ts
@@ -103,7 +103,7 @@ function mergeReaders(readers: StorageFeedReader[]): FeedReader[] {
 		return {
 			id: r.id,
 			name: r.name,
-			link: (feed: string) => r.url.replace("%s", encodeURI(feed)),
+			link: (feed: string) => r.url.replace("%s", encodeURIComponent(feed)),
 			favicon: r.img || "./providers-icons/noname.svg",
 		};
 	});


### PR DESCRIPTION
Previously, pull request #27 by @StigNygaard fixed escaping for feed URLs in predefined readers. This quick pull request applies the same fix for user-defined feed readers.  