### PR TITLE
Add `height: auto` on images to respect aspect ratio

### DIFF
--- a/ext/show.css
+++ b/ext/show.css
@@ -284,6 +284,7 @@ a.header__main-url:visited:hover {
 
 .content img {
 	max-width: 100%;
+	height: auto;
 	object-fit: scale-down;
 	padding: 0.2rem;
 	box-sizing: border-box;


### PR DESCRIPTION
Images with `width` and `height` attributes are resized because of `max-width: 100%`, but the height was kept as is.