### PR TITLE
Improve JSON Feed support

### DIFF
--- a/ts/page.ts
+++ b/ts/page.ts
@@ -1,7 +1,7 @@
 (function () {
 	const data = Array.from(
 		document.querySelectorAll(
-			"link[rel='alternate'][href]:is([type*=atom],[type*=rss],[type=application/json])"
+			"link[rel='alternate'][href]:is([type*=atom],[type*=rss],[type='application/json'],[type='application/feed+json'])"
 		) as NodeListOf<HTMLLinkElement>
 	)
 		.map((el) => ({

--- a/ts/popup.ts
+++ b/ts/popup.ts
@@ -12,6 +12,7 @@ const types: { [key: string]: string } = {
 	"application/rss+xml": "rss",
 	"application/atom+xml": "atom",
 	"application/json": "json",
+	"application/feed+json": "json",
 };
 
 let openInNewTab: boolean = false;


### PR DESCRIPTION
This fixes detection of `application/json` links, which were not detected due to missing quotes in a selector. 

Also, it adds support for `application/feed+json` links, which is the preferred MIME type in [JSON Feed 1.1](https://www.jsonfeed.org/version/1.1/)