### PR TITLE
fix: allow 'rel' attribute to contain other values

### DIFF
--- a/ts/page.ts
+++ b/ts/page.ts
@@ -1,7 +1,7 @@
 (function () {
   const data = Array.from(
     document.querySelectorAll(
-      "link[rel='alternate'][href]:is([type*=atom],[type*=rss],[type='application/json'],[type='application/feed+json'])"
+      "link[rel*=alternate][href]:is([type*=atom],[type*=rss],[type='application/json'],[type='application/feed+json'])"
     ) as NodeListOf<HTMLLinkElement>
   ).map((el) => ({
     type: el.getAttribute("type"),


### PR DESCRIPTION
Some rss links on discuss forums have rel values that contains "nofollow". Such links do not appear in the list of available feeds. 
This solves the issue by checking the rel attribute contains 'alternate' instead of a pure equality.

Example page:  https://discussion.fedoraproject.org/c/news/commblog/61
On that page, there are 3 rss links: 
```
<link rel="alternate" type="application/rss+xml" title="Latest posts" href="https://discussion.fedoraproject.org/posts.rss" />
<link rel="alternate" type="application/rss+xml" title="Latest topics" href="https://discussion.fedoraproject.org/latest.rss" />
<link rel="alternate nofollow" type="application/rss+xml" title="RSS feed of topics in the &#39;Community Blog&#39; category" href="https://discussion.fedoraproject.org/c/news/commblog/61.rss" />
```
Note that the third one contains `rel="alternate nofollow"` and that link does not appear without this proposed patch. 